### PR TITLE
Update Dockerfile to use CVE-Search 4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 ENV CVE_BASE=/opt/cve
 ENV PATH=${PATH}:${CVE_BASE}/bin
-ENV CVE_SEARCH_VERSION=4.0
+ENV CVE_SEARCH_VERSION=4.1.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl cron && \
     curl -s 'https://www.dotdeb.org/dotdeb.gpg' | apt-key add - && \
-    echo "deb http://mirrors.teraren.com/dotdeb/ jessie all" \
+    echo "deb http://packages.dotdeb.org jessie all" \
         > /etc/apt/sources.list.d/dotdeb.list
 
 RUN apt-get update && \


### PR DESCRIPTION
After [cve search v4.1.0](https://github.com/cve-search/cve-search/releases/tag/v4.1.0) was released, the updating and populating process of [lounagen/cve-search:4.0](https://hub.docker.com/layers/lounagen/cve-search/4.0/images/sha256-ee661917f53ae5f53f3fba34923a4b2d4067f167fa675c3fcb30e1419498cb58) does not work anymore.

With an update to 4.1.0 and a fix of a 404 package source, the image can be built and populating/updating works again. This is more of a hotfix; I did not do extensive testing for any functionality that might be broken by the update to a newer version.